### PR TITLE
[CONFIG] Add .editorconfig for consistent code formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig helps maintain consistent coding styles
+# https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
## Summary
- Add EditorConfig file at repository root for consistent coding styles
- Configure UTF-8 charset and LF line endings for cross-platform consistency
- Set 2-space indentation matching CONTRIBUTING.md guidelines
- Preserve trailing whitespace in markdown files (semantic meaning)
- Tab handling for Makefiles

## Changes from PR #68
- **Simplified per CodeRabbit review**: Removed redundant file-type sections that duplicate global `[*]` defaults
- Reduced from 37 lines to 18 lines while maintaining same functionality

## Configuration Details
- **Default settings** (`[*]`): UTF-8, LF, 2 spaces, trim trailing whitespace
- **Markdown** (`[*.md]`): Preserve trailing whitespace
- **Makefiles**: Tab indentation (required by Make syntax)

## Test Plan
- [x] Verified .editorconfig syntax matches EditorConfig specification
- [x] Confirmed alignment with CONTRIBUTING.md (2-space indentation)
- [x] Addressed CodeRabbit nitpick from PR #68

## References
- Closes #48
- Supersedes PR #68 (was squash-merged, reverted to use merge commit)
- [EditorConfig Official Site](https://editorconfig.org/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added EditorConfig configuration to enforce consistent code formatting standards across the repository, including character encoding, line endings, indentation style, and whitespace handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->